### PR TITLE
Create error message

### DIFF
--- a/error message
+++ b/error message
@@ -1,0 +1,1 @@
+Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details.


### PR DESCRIPTION
Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details.
